### PR TITLE
fix: restore getTimeLockState_input struct name

### DIFF
--- a/QuGate.h
+++ b/QuGate.h
@@ -514,6 +514,7 @@ public:
     };
 
     // Query TIME_LOCK state for a gate.
+    struct getTimeLockState_input
     {
         uint32 gateId;
     };


### PR DESCRIPTION
The struct name `getTimeLockState_input` was accidentally deleted in PR #33. Build fails without it.