### PR TITLE
fix: add nextChainGate to sendToGateVerified_locals (build fix)

### DIFF
--- a/QuGate.h
+++ b/QuGate.h
@@ -829,6 +829,8 @@ public:
         routeToGate_input chainIn;
         routeToGate_output chainOut;
         routeToGate_locals chainLocals;
+        // Chain forwarding
+        GateConfig nextChainGate;
         // Multisig processing
         MultisigConfig msigCfg;
         uint8 msigGuardianIdx;


### PR DESCRIPTION
The chain forwarding code added in PR #53 for bug #36 references `locals.nextChainGate` but the field was missing from `sendToGateVerified_locals`. Build fails without it.